### PR TITLE
[PS-0003] Rebuild modals for better iFrame support

### DIFF
--- a/src/modules/QuoteModal/QuoteModal.css
+++ b/src/modules/QuoteModal/QuoteModal.css
@@ -27,6 +27,7 @@
 .pinch-modal .iframe-wrapper {
   max-height: 100%;
   -webkit-overflow-scrolling: touch;
+  overflow-x: auto;
   overflow-y: scroll;
   z-index: 100000;
   max-width: 800px;

--- a/src/modules/QuoteModal/QuoteModal.css
+++ b/src/modules/QuoteModal/QuoteModal.css
@@ -1,38 +1,38 @@
-.modal-open .modal {
-  display: flex !important;
-}
-
-.modal {
-  padding: 0.5rem;
+.pinch-modal {
+  display: flex;
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
   align-items: center;
   justify-content: center;
+  overflow:auto;
+  box-sizing: border-box;
+  padding: 15px;
+  z-index: 9999999;
 }
 
-.modal-dialog.modal-lg {
-  max-height: 100%;
-  box-sizing: border-box;
-  margin: 0;
+.pinch-modal .backdrop {
   display: flex;
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0,0,0,0.85);
+  z-index: 10000;
 }
 
-.modal-content {
-  flex: 1 1 auto;
+.pinch-modal .iframe-wrapper {
   max-height: 100%;
-  box-sizing: border-box;
+  -webkit-overflow-scrolling: touch;
+  overflow-y: scroll;
+  z-index: 100000;
+  max-width: 800px;
 }
 
-.modal-content .modal-body {
-  max-height: 100%;
-  box-sizing: border-box;
-  padding: 0.35rem;
-  height: 100%;
-}
-
-.modal-body iframe {
-  position: relative;
-  display: flex;
-  box-sizing: border-box;
-  margin: 0;
+.pinch-modal iframe {
+  z-index: 100;
   max-width: 100%;
-  max-height: inherit;
 }

--- a/src/modules/QuoteModal/QuoteModal.js
+++ b/src/modules/QuoteModal/QuoteModal.js
@@ -49,11 +49,15 @@ class QuoteModal extends Component {
         let resizeFunction = this.resizeToContent.bind(this);
         resizeFunction();
         this.resizeHandler = setInterval(resizeFunction, 1000);
+        let appNode = document.getElementsByClassName("App")[0];
+        appNode.setAttribute("style", "overflow: hidden;");
       }
       else
       {
         clearInterval(this.resizeHandler);
         this.resizeHandler = null;
+        let appNode = document.getElementsByClassName("App")[0];
+        appNode.setAttribute("style", "");
       }
     }
 }

--- a/src/modules/QuoteModal/QuoteModal.js
+++ b/src/modules/QuoteModal/QuoteModal.js
@@ -1,6 +1,5 @@
 import React, { Component } from 'react';
 import ReactDOM from 'react-dom';
-import { Modal, ModalBody } from 'reactstrap';
 import './QuoteModal.css';
 
 class QuoteModal extends Component {
@@ -16,17 +15,30 @@ class QuoteModal extends Component {
         if (this.element)
         {
             var iframe = this.element.querySelector('iframe');
-            iframe.setAttribute("style", 'width:' + iframe.contentWindow.top.innerWidth + 'px; height:' + iframe.contentWindow.top.innerHeight + 'px');
+            iframe.setAttribute(
+              "style",
+              'width:' + iframe.contentWindow.top.innerWidth + 'px; height: ' + + iframe.contentWindow.top.innerHeight + "px"
+            );
         }
     }
 
     render() {
         return (
-            <Modal isOpen={this.props.modal} toggle={this.props.toggle} className="modal-lg">
-                <ModalBody>
+          <>
+            {
+              this.props.modal && (
+                <div className="pinch-modal">
+                  <div className="backdrop" onClick={this.props.toggle}></div>
+                  <div className="iframe-wrapper">
                     <iframe id="tenants" title="tenants" src="https://st-clair.brokerlift.net/gore-tenants"> </iframe>
-                </ModalBody>
-            </Modal>
+                  </div>
+                </div>
+              )
+            }
+          </>
+            // <Modal isOpen={this.props.modal} toggle={this.props.toggle} className="modal-lg">
+            //   <iframe id="tenants" title="tenants" src="https://st-clair.brokerlift.net/gore-tenants"> </iframe>
+            // </Modal>
         )
     }
 
@@ -45,4 +57,10 @@ class QuoteModal extends Component {
       }
     }
 }
+
+QuoteModal.defaultProps = {
+  modal: false,
+  toggle: ()=>{}
+}
+
 export default QuoteModal;

--- a/src/modules/Rent/Rent.js
+++ b/src/modules/Rent/Rent.js
@@ -25,7 +25,6 @@ class Rent extends Component {
     window.scrollTo(0, 0);
   }
 
-
   render() {
     return (
       <div>


### PR DESCRIPTION
Bootstrap modals are encapsulating the iFrame into multiple layers and has enforced opinions on how this should layout - unfortunately this is incompatible with the limitations of iFrames.
I have wrote a new modal which has no dependencies on the Bootstrap framework - though there are still some inconsistencies due to the web-application as a whole working off Bootstrap.

I do not have an Apple device to test this on, and my trial for BrowserStack has expired. If I were to continue working on compatibility testing I would require a license for BrowserStack or an Apple device.